### PR TITLE
chore: Update composer action and set PHP version

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,8 +19,9 @@ jobs:
             -   uses: actions/checkout@v2
 
             -   name: Install composer dependencies
-                uses: php-actions/composer@v2
+                uses: php-actions/composer@v6
                 with:
+                    php_version: 7.4
                     dev: no
 
             -   uses: actions/setup-node@v1


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the version of the composer action to `v6` and sets a specific PHP version of `7.4`.

