### PR TITLE
fix: Update build for translations

### DIFF
--- a/.github/actions/generate-pot-file/action.yml
+++ b/.github/actions/generate-pot-file/action.yml
@@ -17,7 +17,7 @@ runs:
             run: |
                 npm install -g npm@7
                 npm ci
-                npm run dev
+                npm run build # Must be built for production before generating POT file.
 
         -   name: Generate POT file
             shell: bash

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -55,10 +55,6 @@ jobs:
                     mv wp-cli.phar /usr/local/bin/wp
                     php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,blocks/**/*.js"
 
-            -   name: Build assets for production
-                if: ${{ inputs.install_npm_packages }}
-                run: npm run build
-
             -   name: Generate plugin zip file
                 run: rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "${GITHUB_WORKSPACE}/" ${{ inputs.plugin_slug }}/ --delete --delete-excluded
 

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -46,7 +46,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run dev
+                    npm run build # Must be built for production before generating POT file.
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -46,7 +46,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run build # Must be built for production before generating POT file.
+                    npm run build
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/givewp-release.yml
+++ b/.github/workflows/givewp-release.yml
@@ -57,7 +57,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run build # Must be built for production before generating POT file.
+                    npm run build
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/givewp-release.yml
+++ b/.github/workflows/givewp-release.yml
@@ -57,7 +57,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run dev
+                    npm run build # Must be built for production before generating POT file.
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/givewp-release.yml
+++ b/.github/workflows/givewp-release.yml
@@ -66,9 +66,6 @@ jobs:
                     mv wp-cli.phar /usr/local/bin/wp
                     php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,*.js.map,blocks/**/*.js"
 
-            -   name: Build assets for production
-                run: npm run build
-
             -   name: Generate plugin artifact
                 run: |
                     rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "${GITHUB_WORKSPACE}/" ${{ inputs.plugin_slug }}/ --delete --delete-excluded

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,7 +38,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run dev
+                    npm run build # Must be built for production before generating POT file.
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,7 +38,7 @@ jobs:
                 run: |
                     npm install -g npm@7
                     npm ci
-                    npm run build # Must be built for production before generating POT file.
+                    npm run build
 
             -   name: Generate pot file
                 run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -47,9 +47,6 @@ jobs:
                     mv wp-cli.phar /usr/local/bin/wp
                     php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,*.js.map,blocks/**/*.js"
 
-            -   name: Build assets for production
-                run: npm run build
-
             -   name: Generate plugin artifact
                 run: |
                     rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "${GITHUB_WORKSPACE}/" ${{ inputs.plugin_slug }}/ --delete --delete-excluded


### PR DESCRIPTION
Related https://feedback.givewp.com/bug-reports/p/string-translation-should-work-for-the-donor-dashboard

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the build process when generating translation files.

Before generating the POT file JS assets must be build for production so that translatable strings are parseable by `i18n make-pot`.

An example diff of the `.pot` files created using `dev` vs `build` shows a number of additional strings included when built for production, see https://gist.github.com/kjohnson/24af5ffa34d4835ebca576625ae18aa6.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Locally, running `npm run build` then running the below `i18n make-pot` command should include all translatable strings in JS files.

`php -d xdebug.mode=off "$(which wp)" i18n make-pot . ./languages/local.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,*.js.map,blocks/**/*.js"`