### PR TITLE
Refactor: Add condition for different build config

### DIFF
--- a/.github/workflows/givewp-release.yml
+++ b/.github/workflows/givewp-release.yml
@@ -71,6 +71,12 @@ jobs:
                 with:
                     node-version: '12'
 
+            -   name: Install WP-CLI
+                run: |
+                    curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+                    chmod +x wp-cli.phar
+                    mv wp-cli.phar /usr/local/bin/wp
+
             -   name: Install npm dependencies & build for translation
                 run: |
                     npm install -g npm@7
@@ -79,10 +85,11 @@ jobs:
 
             -   name: Generate pot file
                 run: |
-                    curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-                    chmod +x wp-cli.phar
-                    mv wp-cli.phar /usr/local/bin/wp
-                    php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,*.js.map,blocks/**/*.js"
+                    if [ -f "webpack.config.js" ]; then
+                        php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),*.js.map"
+                    else
+                        php -d xdebug.mode=off "$(which wp)" i18n make-pot ${{github.workspace}} ${{github.workspace}}/languages/${{ inputs.plugin_slug }}.pot --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/*.js,src/**/*.js,*.js.map,blocks/**/*.js"
+                    fi
 
             -   uses: impress-org/givewp-github-actions/.github/actions/generate-changelog@master
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

While most of our plugins are still using Laravel Mix (and some legacy gulpfiles), the Peer-to-peer add-on moved away from Mix and uses Webpack directly.

This results in a minified distribution of the JavaScript for production which obfuscates the `i18n` functions.

```jsx
<Card title={__('Register Team Captain', 'give-peer-to-peer')}>
```
becomes
```js
i.a.createElement(_.a,{title:Qe("Register Team Captain","give-peer-to-peer")}
```

Because of this difference, we need to parse the source JavaScript for plugins using Webpack directly, such as Peer-to-peer.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
