### PR TITLE
Feature: Add PHP compatibility check

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,6 +1,8 @@
 name: PHP Compatibility
 
 on:
+    push:
+    pull_request:
     workflow_call: # Allows you to use this workflow as part of another workflow
     workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
@@ -9,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                testVersion: [ 7.0, 7.4, 8.0 ]
+                testVersion: [ '7.0', '7.4', '8.0' ] # The test versions should be strings to maintain formatting
 
         steps:
             -   uses: actions/checkout@v3
@@ -22,7 +24,9 @@ jobs:
                     coverage: none
 
             -   name: Install packages
-                run: composer global require squizlabs/php_codesniffer phpcompatibility/php-compatibility phpcompatibility/phpcompatibility-wp --no-progress --no-interaction
+                run: |
+                    composer global require squizlabs/php_codesniffer phpcompatibility/php-compatibility --no-progress --no-interaction
+                    phpcs --config-set installed_paths ~/.composer/vendor/phpcompatibility/php-compatibility
 
             -   name: Check
-                run: ./vendor/bin/phpcs -p src/ --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.php }} --warning-severity=0
+                run: phpcs -p src/ --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.testVersion }} --warning-severity=0

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                testVersion: [ '7.0', '7.4', '8.0' ] # The test versions should be strings to maintain formatting
+                testVersion: [ '7.0', '8.0' ] # The test versions should be strings to maintain formatting
 
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,0 +1,28 @@
+name: PHP Compatibility
+
+on:
+    workflow_call: # Allows you to use this workflow as part of another workflow
+    workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                testVersion: [ 7.0, 7.4, 8.0 ]
+
+        steps:
+            -   uses: actions/checkout@v3
+
+            -   name: Set up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                    coverage: none
+
+            -   name: Install packages
+                run: composer global require squizlabs/php_codesniffer phpcompatibility/php-compatibility phpcompatibility/phpcompatibility-wp --no-progress --no-interaction
+
+            -   name: Check
+                run: ./vendor/bin/phpcs -p src/ --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.php }} --warning-severity=0


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the `php-compatibility` workflow for using `php_codesniffer` and the `PHPCompatibility` standard to verify compatibility with multiple version of PHP ie `7.0`, `7.4`, and `8.0`.  

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/231845488-e156518d-6c10-4e38-a23d-5192ec9153f0.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

A copy of this new workflow has been added to the [debug/php-compatibility](https://github.com/impress-org/givewp/tree/debug/php-compatibility) branch of the GiveWP repository. Pushing changes to this branch will trigger the workflow.