### PR TITLE
Fix: Build non-prod zip names with an 8 character hash

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -76,7 +76,7 @@ jobs:
                         echo "NEW_VERSION=" >> $GITHUB_ENV
                         echo "NEW_VERSION_WITH_SEPARATOR=" >> $GITHUB_ENV
                     else
-                        NEW_VERSION=${{ env.VERSION }}-dev-$(git show -s --format=%ct HEAD)-$(git rev-parse --short HEAD)
+                        NEW_VERSION=${{ env.VERSION }}-dev-$(git show -s --format=%ct HEAD)-$(git rev-parse --short=8 HEAD)
                         echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
                         echo "NEW_VERSION_WITH_SEPARATOR=.$NEW_VERSION" >> $GITHUB_ENV
                     fi


### PR DESCRIPTION
## Description

In order for other bot-based zip handling process to function, the hash that is used for zip filename generation needs to use an 8 character hash.

## Affects

This will only impact zip filenames that are generated using the `-dev-<timestamp>-<hash>` approach.